### PR TITLE
fix(@deip/platform-components): fix form factory mixin

### DIFF
--- a/packages/casimir/platform/components/lib/mixins/form.js
+++ b/packages/casimir/platform/components/lib/mixins/form.js
@@ -38,7 +38,7 @@ const formFactory = (
 
   data() {
     return {
-      lazyFormData,
+      lazyFormData: cloneDeep(lazyFormData),
 
       disabled: false,
       loading: false,


### PR DESCRIPTION
Now the form fields will be cleared when leaving the page where it was used